### PR TITLE
allow `LruTimestamp::get_timestamp()` to return owned or referenced value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ name = "associative-cache"
 readme = "./README.md"
 repository = "https://github.com/fitzgen/associative-cache"
 version = "1.0.1"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Enable get_timestamp() to return a computed value, rather than only
being able to return a reference into the containing struct.

Note: this is a breaking change for consumers of the LruTimestamp trait.

Uses Generic Associated Types, which requires Rust 1.65.

Closes #16