### PR TITLE
Update rand to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = { version = "0.8.5", optional = true }
+rand = { version = "0.10.0", optional = true }
 
 [profile.bench]
 debug = true

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 associative-cache = { path = "../..", features = ["rand"] }
 quickcheck = "1.0.3"
-rand = "0.8.5"
+rand = "0.10.0"
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,8 +9,7 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-bufrng = "1"
-quickcheck = "0.9"
+quickcheck = "1.0.3"
 
 [dependencies.associative-cache-test-utils]
 path = "../crates/test-utils"

--- a/fuzz/fuzz_targets/four_way.rs
+++ b/fuzz/fuzz_targets/four_way.rs
@@ -1,12 +1,12 @@
 #![no_main]
 
 use associative_cache_test_utils::*;
-use bufrng::BufRng;
 use libfuzzer_sys::fuzz_target;
-use quickcheck::Arbitrary;
+use quickcheck::{Arbitrary, Gen};
 
-fuzz_target!(|data: &[u8]| {
-    let mut gen = quickcheck::StdGen::new(BufRng::new(data), std::cmp::max(data.len(), 1));
+fuzz_target!(|input: (u8, u64)| {
+    let (size, seed) = input;
+    let mut gen = Gen::from_size_and_seed(size.max(1) as usize, seed);
     let test = MethodCalls::arbitrary(&mut gen);
     if let Err(e) = test.run::<Capacity32, HashFourWay, RoundRobinReplacement>() {
         panic!("error: {}", e);

--- a/fuzz/fuzz_targets/two_way.rs
+++ b/fuzz/fuzz_targets/two_way.rs
@@ -1,12 +1,12 @@
 #![no_main]
 
 use associative_cache_test_utils::*;
-use bufrng::BufRng;
 use libfuzzer_sys::fuzz_target;
-use quickcheck::Arbitrary;
+use quickcheck::{Arbitrary, Gen};
 
-fuzz_target!(|data: &[u8]| {
-    let mut gen = quickcheck::StdGen::new(BufRng::new(data), std::cmp::max(data.len(), 1));
+fuzz_target!(|input: (u8, u64)| {
+    let (size, seed) = input;
+    let mut gen = Gen::from_size_and_seed(size.max(1) as usize, seed);
     let test = MethodCalls::arbitrary(&mut gen);
     if let Err(e) = test.run::<Capacity32, HashTwoWay, RoundRobinReplacement>() {
         panic!("error: {}", e);

--- a/src/replacement.rs
+++ b/src/replacement.rs
@@ -54,9 +54,7 @@ pub struct RandomReplacement<R = rand::rngs::StdRng> {
 impl Default for RandomReplacement<rand::rngs::StdRng> {
     #[inline]
     fn default() -> Self {
-        use rand::{Rng, SeedableRng};
-        let rng = rand::rngs::StdRng::seed_from_u64(rand::rngs::OsRng.gen());
-        RandomReplacement { rng }
+        RandomReplacement { rng: rand::make_rng() }
     }
 }
 


### PR DESCRIPTION
Minor adaption was needed to follow their API changes. We can simply use [rand::make_rng](https://docs.rs/rand/latest/rand/fn.make_rng.html) to make a seeded StdRng since 0.9.0.